### PR TITLE
fix wrong path to package.json

### DIFF
--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -4,7 +4,7 @@
 
 import { MixinLimit, MixinLimits } from './MixinLimits';
 
-const version = require('../package.json').version;
+const version = require('../../package.json').version;
 
 /**
  * Configuration for the wallet backend.


### PR DESCRIPTION
In the compiled module, the directory structure is as follows:

```
.
package.json
├── dist
│   └── lib
└── node_modules
    ├── lodash
    │   └── fp
    └── typescript
        ├── bin
        └── lib
```