### PR TITLE
don't spam the terminal with duplicate log messages

### DIFF
--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -13,6 +13,11 @@ class Logger {
      */
     private callback?: (prettyMessage: string, message: string, level: LogLevel, categories: LogCategory[]) => any;
 
+    /**
+     * The last log line emitted
+     */
+    private lastLine: string = '';
+
     constructor(
         level?: LogLevel,
         callback?: (prettyMessage: string, message: string, level: LogLevel, categories: LogCategory[]) => any) {
@@ -50,11 +55,18 @@ class Logger {
 
         output += `: ${message}`;
 
+        // don't spam the console with duplicate messages
+        if (this.getLastLine() === output) {
+            return;
+        }
+
         if (level >= this.logLevel) {
             /* If the user provides a callback, log to that instead */
             if (this.callback) {
+                this.setLastLine(output);
                 this.callback(output, message, level, categories);
             } else {
+                this.setLastLine(output);
                 console.log(output);
             }
         }
@@ -94,6 +106,14 @@ class Logger {
                    categories: LogCategory[]) => any) {
 
         this.callback = callback;
+    }
+
+    private setLastLine(line: string): void {
+        this.lastLine = line;
+    }
+
+    private getLastLine(): string {
+        return this.lastLine;
     }
 }
 


### PR DESCRIPTION
Because of the changes in #76, the Logger is dumping a LOT of duplicate log messages to the terminal, as seen here:

![duplicate_logs](https://user-images.githubusercontent.com/35851667/71552215-e077fa00-29b5-11ea-9158-ade97174375d.png)

This decreases the readability of the log file when it is outputted to a text file greatly, hundreds of unnecessary duplicate lines are added.

I've made changes the logger to not log a message if it is identical to the previous message. This solves the problem, although perhaps there's a better way to solve this. Here's the output with my patch:

![log_fix](https://user-images.githubusercontent.com/35851667/71552225-069d9a00-29b6-11ea-8146-553a5225f906.png)

We could also potentially check only the message portion of the log output and not the timestamp and further reduce duplicates. What are your thoughts?