### PR TITLE
Fixing swapNode and daemon events tests

### DIFF
--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -25,7 +25,7 @@ import { ValidateParametersTests } from './lib/ValidateParametersTests'
 
 const doPerformanceTests: boolean = process.argv.includes('--do-performance-tests');
 
-const daemonAddress = 'fastpool.xyz';
+const daemonAddress = 'public.turtlenode.net';
 const daemonPort = 11898;
 
 function delay(ms: number): Promise<void> {


### PR DESCRIPTION
Using `public.turtlenode.net` instead of `fastpool.xyz`; not sure if this is the solution we want or not.

Tried instantiating another `Daemon` on `127.0.0.1` on a different port with no luck.